### PR TITLE
修复邮件发送OTP时, 邮件配置SSL未启用导致发送失败的问题

### DIFF
--- a/maxkey-starter/maxkey-starter-otp/src/main/java/org/dromara/maxkey/password/onetimepwd/impl/MailOtpAuthn.java
+++ b/maxkey-starter/maxkey-starter-otp/src/main/java/org/dromara/maxkey/password/onetimepwd/impl/MailOtpAuthn.java
@@ -66,6 +66,8 @@ public class MailOtpAuthn extends AbstractOtpAuthn {
             javaMailSender.setPassword(emailConfig.getPassword());
             Properties properties = new Properties();
             properties.put("mail.smtp.auth","true");
+            properties.put("mail.smtp.ssl.enable", String.valueOf(emailConfig.isSsl()));
+            properties.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
             javaMailSender.setJavaMailProperties(properties);
             javaMailSender.setHost(emailConfig.getSmtpHost());
             javaMailSender.setPort(emailConfig.getPort());


### PR DESCRIPTION
resolve #254 

添加配置开关值到 JavaMailSenderImpl 里