### PR TITLE
修复 编辑应用 生成应用密钥无法自动回填

### DIFF
--- a/maxkey-webs/maxkey-web-mgt/src/main/java/org/dromara/maxkey/web/apps/contorller/ApplicationsController.java
+++ b/maxkey-webs/maxkey-web-mgt/src/main/java/org/dromara/maxkey/web/apps/contorller/ApplicationsController.java
@@ -190,7 +190,7 @@ public class ApplicationsController extends BaseAppContorller {
             secret=StringGenerator.generateKey("");
         }
         
-        return new Message<>(Message.SUCCESS,secret);
+        return new Message<>(Message.SUCCESS,null,secret);
     }
     
     


### PR DESCRIPTION
```java
    public Message(int code, String message) {
        this.code = code;
        this.message = message;
    }
    
    public Message(int code, String message, T data) {
        this.code = code;
        this.message = message;
        this.data = data;
    }
    
    public Message(int code, T data) { 
        // FIXME  这个方法重载可能引起不必要的问题, 当 data 为 String 的时候 可能会变成 message 返回 而不是 data, 如有可能建议移除
        this.code = code;
        this.data = data;
    }
```
生成应用密钥无法自动回填 也是因为 返回的 data 为 String 类型 应该是走了 上面 code + message 的重载, 导致前端从 data 中取数据取不到

附前端代码
```javascript
  onGenerateSecret(e: MouseEvent): void {
    e.preventDefault();
    this.appsService.generateSecret('base').subscribe(res => {
      this.form.model.secret = res.data;
      this.cdr.detectChanges();
    });
  }
```